### PR TITLE
Add the GameSir-G8+ profile

### DIFF
--- a/android/GameSir-G8+.cfg
+++ b/android/GameSir-G8+.cfg
@@ -1,0 +1,38 @@
+input_driver = "android"
+input_device = "GameSir-G8+"
+input_vendor_id = "13623"
+input_product_id = "4360"
+
+input_up_btn = "h0up"
+input_down_btn = "h0down"
+input_left_btn = "h0left"
+input_right_btn = "h0right"
+
+input_l_x_plus_axis = "+0"
+input_l_x_minus_axis = "-0"
+input_l_y_plus_axis = "+1"
+input_l_y_minus_axis = "-1"
+
+input_r_x_plus_axis = "+2"
+input_r_x_minus_axis = "-2"
+input_r_y_plus_axis = "+3"
+input_r_y_minus_axis = "-3"
+
+input_a_btn = "97"
+input_a_btn_label = "B"
+input_b_btn = "96"
+input_b_btn_label = "A"
+input_x_btn = "100"
+input_x_btn_label = "Y"
+input_y_btn = "99"
+input_y_btn_label = "X"
+
+input_l_btn = "102"
+input_r_btn = "103"
+input_l2_btn = "104"
+input_r2_btn = "105"
+input_l3_btn = "106"
+input_r3_btn = "107"
+
+input_select_btn = "109"
+input_start_btn = "108"


### PR DESCRIPTION
This will add the GameSir-G8+ profile, which is nearly identical to the GAMESIR GameSir-G8.cfg. 

The only difference is the `input_device = "GameSir-G8+"` and `input_product_id = "4360"`.